### PR TITLE
Fix blocked key bypass in AdministrativelyRevokeCertificate

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2043,8 +2043,10 @@ func (ra *RegistrationAuthorityImpl) AdministrativelyRevokeCertificate(ctx conte
 			if err != nil {
 				return nil, err
 			}
+			// Fall through to addToBlockedKeys below.
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	if reasonCode == revocation.KeyCompromise && !req.SkipBlockKey {


### PR DESCRIPTION
## Security Fix: Blocked key bypass in administrative certificate revocation

### Vulnerability

In `AdministrativelyRevokeCertificate`, when an admin re-revokes a certificate for `keyCompromise` that was already revoked for another reason (e.g., `cessationOfOperation`), the following sequence occurs:

1. `SA.RevokeCertificate` returns `AlreadyRevoked` error
2. `updateRevocationForKeyCompromise` succeeds, setting `err` to `nil`
3. The outer `if err != nil` block still executes `return nil, err` (now `return nil, nil`)
4. **The function returns early, completely skipping `addToBlockedKeys`**

This means the compromised key is never added to the `blockedKeys` table, allowing continued certificate issuance with that key.

### Fix

Restructured the error handling so that after a successful re-revocation for `keyCompromise`, execution falls through to the `addToBlockedKeys` block instead of returning early. Non-keyCompromise errors still return immediately via the new `else` branch.

### Comparison with existing correct pattern

`RevokeCertByKey` (lines 1897-1932) correctly calls `addToBlockedKeys` *before* attempting revocation, ensuring the key is always blocked. This fix ensures `AdministrativelyRevokeCertificate` also always blocks the key when revoking for key compromise.